### PR TITLE
Reduced overhead on unneeded malloc calls

### DIFF
--- a/src/delsparse.f90
+++ b/src/delsparse.f90
@@ -2905,11 +2905,11 @@ FORALL (I = 1:M) Q(:,I) = (Q(:,I) - PTS_CENTER(:)) / SCALE
 IF (EXACTL) THEN
    ! If exact error error checking is turned on, then compute the DIAMETER
    ! and MINDIST values.
-   !$OMP PARALLEL DO &
-   !$OMP& PRIVATE(I, DISTANCE),    &
-   !$OMP& REDUCTION(MAX:DIAMETER), &
-   !$OMP& REDUCTION(MIN:MINDIST),  &
-   !$OMP& SCHEDULE(STATIC, 100),   &
+   !$OMP PARALLEL DO                      &
+   !$OMP& PRIVATE(I, DISTANCE, WORK_TMP), &
+   !$OMP& REDUCTION(MAX:DIAMETER),        &
+   !$OMP& REDUCTION(MIN:MINDIST),         &
+   !$OMP& SCHEDULE(STATIC, 100),          &
    !$OMP& DEFAULT(SHARED)
    DO I = 1, N ! Cycle through all pairs of points.
       DO J = I + 1, N

--- a/src/delsparse.f90
+++ b/src/delsparse.f90
@@ -260,18 +260,21 @@ SUBROUTINE DELAUNAYSPARSES( D, N, PTS, M, Q, SIMPS, WEIGHTS, IERR, &
 !
 ! EXACT is a logical input argument that determines whether the exact
 !    diameter should be computed and whether a check for duplicate data
-!    points should be performed in advance. When EXACT=.FALSE., the
-!    diameter of PTS is approximated by twice the distance from the
-!    barycenter of PTS to the farthest point in PTS, and no check is
-!    done to find the closest pair of points, which could result in hard
-!    to find bugs later on. When EXACT=.TRUE., the exact diameter is
-!    computed and an error is returned whenever PTS contains duplicate
-!    values up to the precision EPS. By default EXACT=.TRUE., but setting
-!    EXACT=.FALSE. could result in significant speedup when N is large.
-!    It is strongly recommended that most users leave EXACT=.TRUE., as
+!    points should be performed in advance. These checks are O(N^2 D) time
+!    complexity, while DELAUNAYSPARSE tends toward O(N D^4) on average.
+!    By default, EXACT=.TRUE. and the exact diameter is computed and an error
+!    is returned whenever PTS contains duplicate values up to the precision
+!    EPS. When EXACT=.FALSE., the diameter of PTS is approximated by twice
+!    the distance from the barycenter of PTS to the farthest point in PTS,
+!    and no check is done to find the closest pair of points.
+!    When EXACT=.TRUE., DELAUNAYSPARSE could spend over 90% of runtime
+!    calculating these constants, which are not critical to the DELAUNAYSPARSE
+!    algorithm. In particular, this happens for large values of N. However,
 !    setting EXACT=.FALSE. could result in input errors that are difficult
-!    to identify. Also, the diameter approximation could be wrong by up to
-!    a factor of two.
+!    to identify. It is recommended that users verify the input set PTS
+!    and possibly rescale PTS manually while EXACT=.TRUE. Then, when
+!    100% sure that PTS is valid, users may choose to set EXACT=.FALSE.
+!    in production runs for large values of N to achieve massive speedups.
 !
 !
 ! Subroutines and functions directly referenced from BLAS are
@@ -1348,18 +1351,21 @@ SUBROUTINE DELAUNAYSPARSEP( D, N, PTS, M, Q, SIMPS, WEIGHTS, IERR,  &
 !
 ! EXACT is a logical input argument that determines whether the exact
 !    diameter should be computed and whether a check for duplicate data
-!    points should be performed in advance. When EXACT=.FALSE., the
-!    diameter of PTS is approximated by twice the distance from the
-!    barycenter of PTS to the farthest point in PTS, and no check is
-!    done to find the closest pair of points, which could result in hard
-!    to find bugs later on. When EXACT=.TRUE., the exact diameter is
-!    computed and an error is returned whenever PTS contains duplicate
-!    values up to the precision EPS. By default EXACT=.TRUE., but setting
-!    EXACT=.FALSE. could result in significant speedup when N is large.
-!    It is strongly recommended that most users leave EXACT=.TRUE., as
+!    points should be performed in advance. These checks are O(N^2 D) time
+!    complexity, while DELAUNAYSPARSE tends toward O(N D^4) on average.
+!    By default, EXACT=.TRUE. and the exact diameter is computed and an error
+!    is returned whenever PTS contains duplicate values up to the precision
+!    EPS. When EXACT=.FALSE., the diameter of PTS is approximated by twice
+!    the distance from the barycenter of PTS to the farthest point in PTS,
+!    and no check is done to find the closest pair of points.
+!    When EXACT=.TRUE., DELAUNAYSPARSE could spend over 90% of runtime
+!    calculating these constants, which are not critical to the DELAUNAYSPARSE
+!    algorithm. In particular, this happens for large values of N. However,
 !    setting EXACT=.FALSE. could result in input errors that are difficult
-!    to identify. Also, the diameter approximation could be wrong by up to
-!    a factor of two.
+!    to identify. It is recommended that users verify the input set PTS
+!    and possibly rescale PTS manually while EXACT=.TRUE. Then, when
+!    100% sure that PTS is valid, users may choose to set EXACT=.FALSE.
+!    in production runs for large values of N to achieve massive speedups.
 !
 ! PMODE is an integer specifying the level of parallelism to be exploited.
 !    If PMODE = 1, then parallelism is exploited at the level of the loop


### PR DESCRIPTION
For certain compilers, performing a computation (such as ``PTS(:,I) - CENTER(:)``) inside the call to a function (such as ``DNRM2``) implicitly allocates a temporary work array.  For such function calls that occur inside a loop, a better strategy is to pre-allocate the work array outside the loop, perform the subtraction prior to the function call, and explicitly store the temporary value in the pre-allocated work array.

Many compilers will do this automatically, however, ``gfortran`` does not appear to.

This results in a performance hit for certain problems where the Linux ``perf`` tool reveals that up to 5-10% of execution time could be spent in calls to ``c_malloc``.

To resolve the issue, we have explicitly pre-computed these subtractions in ``DELAUNAYSPARSE``'s ``WORK`` arrays.

In addition, we have documented the cost of using ``EXACT`` pre-scaling, which could optionally be disabled for production runs.